### PR TITLE
add support for changing the model with --model/-m

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/verdverm/chatgpt
 go 1.18
 
 require (
-	github.com/sashabaranov/go-gpt3 v1.0.1
+	github.com/sashabaranov/go-openai v1.5.0
 	github.com/spf13/cobra v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-gpt3 v1.0.1 h1:KHwY4uroFlX1qI1Hui7d31ZI6uzbNGL9zAkh1FkfhuM=
-github.com/sashabaranov/go-gpt3 v1.0.1/go.mod h1:BIZdbwdzxZbCrcKGMGH6u2eyGe1xFuX9Anmh3tCP8lQ=
+github.com/sashabaranov/go-openai v1.5.0 h1:4Gr/7g/KtVzW0ddn7TC2aUlyzvhZBIM+qRZ6Ae2kMa0=
+github.com/sashabaranov/go-openai v1.5.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
Does exactly what it says on the tin. Does not support custom models yet. Here is a usage example:

```plain

$ ./chatgpt -m text-davinci-003 -q "Explain what the following shell command does: awk 'NF>1'"

This command uses the awk utility to print the lines that contain more than one field (column). This can be used, for example, to process a text file and select all lines with more than one word.
$ ./chatgpt -m text-curie-001 -q "Explain what the following shell command does: awk 'NF>1'"

This shell command uses awk to print the first line of every file in the current directory, excluding the file named NF. Because NF is a file name, the command prints nothing, which is what you would expect.
$ ./chatgpt -m text-babbage-001 -q "Explain what the following shell command does: awk 'NF>1'"

This shell command prints the string "Yes, $1" to the console.
```