### PR TITLE
Fix bug for when no input is piped but -q is used

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,9 @@ func main() {
 
 			// no args, or interactive... read from stdin
 			// this is mainly for replacing text in vim
-			if len(args) == 0 && !PromptMode {
+			fi, _ := os.Stdin.Stat()
+			inputIsFromPipe = (fi.Mode() & os.ModeCharDevice) == 0
+			if len(args) == 0 && !PromptMode && inputIsFromPipe {
 				reader := bufio.NewReader(os.Stdin)
 				var buf bytes.Buffer
 				for {


### PR DESCRIPTION
My last patch broke this:

```
$ chatgpt -q "question"
the program is waiting for stdin in all cases, so it hangs...
```

This fix checks if stdin is coming from a pipe and only reads if it is.